### PR TITLE
IO Optimizations and ObjectMember Key Support

### DIFF
--- a/Xpand/Xpand.ExpressApp.Modules/IO/Core/ExportEngine.cs
+++ b/Xpand/Xpand.ExpressApp.Modules/IO/Core/ExportEngine.cs
@@ -130,9 +130,15 @@ namespace Xpand.ExpressApp.IO.Core {
         void CreateRefKeyElements(IEnumerable<IClassInfoGraphNode> serializedClassInfoGraphNodes, XPBaseObject theObject,
                                   XElement serializedObjectRefElement) {
             foreach (var infoGraphNode in serializedClassInfoGraphNodes.Where(node => node.Key)) {
+                var value = theObject.GetMemberValue(infoGraphNode.Name);
                 var serializedObjectRefKeyElement = new XElement("Key");
                 serializedObjectRefKeyElement.Add(new XAttribute("name", infoGraphNode.Name));
-                serializedObjectRefKeyElement.Value = theObject.GetMemberValue(infoGraphNode.Name).ToString();
+                
+                if (value is XPBaseObject)
+                    CreateRefElelement(infoGraphNode, value.GetType().Name, root, ((XPBaseObject)value), serializedObjectRefKeyElement);
+                else
+                    SetMemberValue(theObject, infoGraphNode, serializedObjectRefKeyElement);
+
                 serializedObjectRefElement.Add(serializedObjectRefKeyElement);
             }
         }

--- a/Xpand/Xpand.ExpressApp.Modules/IO/Core/SerializeClassInfoGraphNodesCalculator.cs
+++ b/Xpand/Xpand.ExpressApp.Modules/IO/Core/SerializeClassInfoGraphNodesCalculator.cs
@@ -20,8 +20,9 @@ namespace Xpand.ExpressApp.IO.Core {
         ISerializationConfiguration GetConfiguration(Session session, Type type) {
             var serializationConfigurationType = TypesInfo.Instance.SerializationConfigurationType;
             ISerializationConfiguration configuration;
-            var findObject = session.FindObject(PersistentCriteriaEvaluationBehavior.InTransaction, serializationConfigurationType,
-                                                SerializationConfigurationQuery.GetCriteria(type, _serializationConfigurationGroup));
+
+            var findObject = _serializationConfigurationGroup.Configurations.FirstOrDefault(a => a.TypeToSerialize == type);
+
             if (findObject != null)
                 configuration = (ISerializationConfiguration)findObject;
             else {

--- a/Xpand/Xpand.ExpressApp.Modules/IO/Core/XmlExtensions.cs
+++ b/Xpand/Xpand.ExpressApp.Modules/IO/Core/XmlExtensions.cs
@@ -82,20 +82,16 @@ namespace Xpand.ExpressApp.IO.Core {
 
         public static XElement FindObjectFromRefenceElement(this XElement xElement) {
             var typeValue = xElement.GetAttributeValue("type");
-            var infos = xElement.Descendants("Key").Select(
+            var infos = xElement.Elements("Key").Select(
                 element1 => new { Element = element1, Name = element1.GetAttributeValue("name"), element1.Value });
-            if (xElement.Document != null && xElement.Document.Root != null)
-            {
-                var @select =
-                    xElement.Document.Root.SerializedObjects().Where(
-                        element => element.GetAttributeValue("type") == typeValue).Descendants("Property").Where(
-                        xElement1 => xElement1.GetAttributeValue("isKey") == "true").
-                        Select(element1 =>
-                        new { Element = element1.Parent, Name = element1.GetAttributeValue("name"), element1.Value });
+            if (xElement.Document != null && xElement.Document.Root != null && infos.Count() > 0) {
                 return
-                    @select.Where(
-                        arg => infos.Where(arg1 => arg.Name == arg1.Name && arg.Value == arg1.Value).Count() > 0).
-                        Select(arg2 => arg2.Element).FirstOrDefault();
+                    xElement.Document.Root.SerializedObjects().Where(
+                        element => element.GetAttributeValue("type") == typeValue).FirstOrDefault(
+                        element => !element.Elements("Property").Where(
+                        xElement1 => xElement1.GetAttributeValue("isKey") == "true").Any(xElement2 =>
+                        xElement2.Value != infos.FirstOrDefault(a => a.Name == xElement2.GetAttributeValue("name")).Value
+                        ));
             }
             return null;
 

--- a/Xpand/Xpand.ExpressApp.Modules/IO/PersistentTypesHelpers/ClassInfoGraphNodeBuilder.cs
+++ b/Xpand/Xpand.ExpressApp.Modules/IO/PersistentTypesHelpers/ClassInfoGraphNodeBuilder.cs
@@ -38,19 +38,9 @@ namespace Xpand.ExpressApp.IO.PersistentTypesHelpers {
         IEnumerable<IClassInfoGraphNode> CreateGraph(IObjectSpace objectSpace, ITypeInfo typeToSerialize) {
             var memberInfos = GetMemberInfos(typeToSerialize);
             var classInfoGraphNodes = CreateGraphCore(memberInfos, objectSpace).ToArray();
-            ResetDefaultKeyWhenMultiple(classInfoGraphNodes);
             return classInfoGraphNodes;
         }
-
-        void ResetDefaultKeyWhenMultiple(IEnumerable<IClassInfoGraphNode> classInfoGraphNodes) {
-            var infoGraphNodes = classInfoGraphNodes as IClassInfoGraphNode[] ?? classInfoGraphNodes.ToArray();
-            var nonDefaultKey = infoGraphNodes.Skip(1).FirstOrDefault(node => node.Key);
-            if (nonDefaultKey != null) {
-                infoGraphNodes.First(graphNode => graphNode.Key).Key = false;
-            }
-        }
-
-
+        
         IEnumerable<IClassInfoGraphNode> CreateGraphCore(IEnumerable<IMemberInfo> memberInfos, IObjectSpace objectSpace) {
             return memberInfos.Select(memberInfo => (!memberInfo.MemberTypeInfo.IsPersistent && !memberInfo.IsList) || memberInfo.MemberType == typeof(byte[])
                                                                                     ? CreateSimpleNode(memberInfo, objectSpace)
@@ -65,7 +55,8 @@ namespace Xpand.ExpressApp.IO.PersistentTypesHelpers {
             NodeType nodeType = memberInfo.MemberTypeInfo.IsPersistent ? NodeType.Object : NodeType.Collection;
             IClassInfoGraphNode classInfoGraphNode = CreateClassInfoGraphNode(objectSpace, memberInfo, nodeType);
             classInfoGraphNode.SerializationStrategy = GetSerializationStrategy(memberInfo, SerializationStrategy.SerializeAsObject);
-            Generate(objectSpace, ReflectionHelper.GetType(classInfoGraphNode.TypeName));
+            if (classInfoGraphNode.SerializationStrategy == SerializationStrategy.SerializeAsObject)
+                Generate(objectSpace, ReflectionHelper.GetType(classInfoGraphNode.TypeName));
             return classInfoGraphNode;
 
         }
@@ -98,7 +89,8 @@ namespace Xpand.ExpressApp.IO.PersistentTypesHelpers {
             classInfoGraphNode.SerializationStrategy = GetSerializationStrategy(memberInfo, classInfoGraphNode.SerializationStrategy);
             classInfoGraphNode.TypeName = GetSerializedType(memberInfo).Name;
             classInfoGraphNode.NodeType = nodeType;
-            classInfoGraphNode.Key = IsKey(memberInfo);
+            if (classInfoGraphNode.SerializationStrategy != SerializationStrategy.DoNotSerialize)
+                classInfoGraphNode.Key = IsKey(memberInfo);
             return classInfoGraphNode;
         }
 


### PR DESCRIPTION
Import/Export engines:

- Objects as serialization key - ComplexMembers like Objects now
supports SerializationKey attribute properly.
- RefElelement's keys values are now safely exported, like properties
values.
- The FindObjectFromRefenceElement method will find an element where all
keys matches, instead of the first element where at least one key member
match.
- Importer keeps a reference of all imported objects, instead of running
InTransaction queries to get the reference everytime - It supports
SerializationKeys objects scenarios.
- When exporting, it will no longer query the database for the
SerializationConfiguration object on every single record export, which
was unnecessary.

Graph Generation:

- If the property strategy is set to DoNotSerialize at model, it will no
longer be set as key.
- A graph for a related member will only be generated if the member
serialize strategy is set to object or value.
- It will no longer clear the second key avaliable, on function
ResetDefaultKeyWhenMultiple, because it makes no sense to remove a key
you have set with SerializationKeyAttribute.​