### PR TITLE
fix assembly identity of Xpand.ExpressApp.EasyTest.WinAdapter

### DIFF
--- a/Xpand.EasyTest/Xpand.ExpressApp.EasyTest.WinAdapter/Properties/AssemblyInfo.cs
+++ b/Xpand.EasyTest/Xpand.ExpressApp.EasyTest.WinAdapter/Properties/AssemblyInfo.cs
@@ -4,11 +4,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Xpand.Utils")]
+[assembly: AssemblyTitle("Xpand.ExpressApp.EasyTest.WinAdapter")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Xpand.Utils")]
+[assembly: AssemblyProduct("Xpand.ExpressApp.EasyTest.WinAdapter")]
 [assembly: AssemblyCopyright("Copyright © 2009")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -19,7 +19,7 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("14e87e2c-acc6-45bf-bf56-865662d32223")]
+[assembly: Guid("52895492-8B46-4D72-A080-90565D019D8F")]
 
 // Version information for an assembly consists of the following four values:
 //


### PR DESCRIPTION
  It was using same info as Xpand.Utils, causing Xpand.Utils to appear 2x in the VS "Reference Manager" with only 1 being correct