### PR TITLE
Ignore possible SecurityException from InterfaceBuilder.IsDevMachine

### DIFF
--- a/Xpand/Xpand.Persistent/Xpand.Persistent.Base/ModelAdapter/InterfaceBuilder.cs
+++ b/Xpand/Xpand.Persistent/Xpand.Persistent.Base/ModelAdapter/InterfaceBuilder.cs
@@ -123,7 +123,16 @@ namespace Xpand.Persistent.Base.ModelAdapter{
             return compileAssemblyFromSource;
         }
 
-        public bool IsDevMachine => Environment.GetEnvironmentVariable("XpandDevMachine", EnvironmentVariableTarget.User).Change<bool>();
+        public bool IsDevMachine {
+            get {
+                try {
+                    return  Environment.GetEnvironmentVariable("XpandDevMachine", EnvironmentVariableTarget.User).Change<bool>();
+                }
+                catch (System.Security.SecurityException) {
+                    return false;
+                }
+            }
+        }
 
         public static bool IsDBUpdater => Process.GetCurrentProcess().ProcessName.StartsWith("DBUpdater"+AssemblyInfo.VSuffix);
 


### PR DESCRIPTION
I was getting this SecurityException on a dev machine under full IIS using the ApplicationPoolIdentity