### PR TITLE
Fixes DockManagerOnLoad throws Sequence contains no matching element 

### DIFF
--- a/Xpand/Xpand.Persistent/Xpand.Persistent.Base/General/Controllers/NavigationController.cs
+++ b/Xpand/Xpand.Persistent/Xpand.Persistent.Base/General/Controllers/NavigationController.cs
@@ -73,7 +73,7 @@ namespace Xpand.Persistent.Base.General.Controllers {
 
         private void DockManagerOnLoad(object sender, EventArgs eventArgs) {
             _navigationPanel = ((DockManager)sender).Panels.FirstOrDefault(panel => panel.Name == "dockPanelNavigation");
-			if (_navigationPanel == null)
+            if (_navigationPanel == null)
                 return;
             var hideNavigationOnStartup = ((IModelOptionsNavigationContainer)Application.Model.Options).HideNavigationOnStartup;
             _navigationPanel.Visibility = hideNavigationOnStartup != null && hideNavigationOnStartup.Value ? DockVisibility.AutoHide : DockVisibility.Visible;

--- a/Xpand/Xpand.Persistent/Xpand.Persistent.Base/General/Controllers/NavigationController.cs
+++ b/Xpand/Xpand.Persistent/Xpand.Persistent.Base/General/Controllers/NavigationController.cs
@@ -59,6 +59,8 @@ namespace Xpand.Persistent.Base.General.Controllers {
         }
 
         private void ToggleNavigationOnExecute(object sender, SimpleActionExecuteEventArgs simpleActionExecuteEventArgs) {
+			if (_navigationPanel == null)
+                return;
             _navigationPanel.Visibility = _navigationPanel.Visibility == DockVisibility.Visible ? DockVisibility.Hidden : DockVisibility.Visible;
             System.Windows.Forms.Application.DoEvents();
         }
@@ -70,7 +72,9 @@ namespace Xpand.Persistent.Base.General.Controllers {
         }
 
         private void DockManagerOnLoad(object sender, EventArgs eventArgs) {
-            _navigationPanel = ((DockManager)sender).Panels.First(panel => panel.Name == "dockPanelNavigation");
+            _navigationPanel = ((DockManager)sender).Panels.FirstOrDefault(panel => panel.Name == "dockPanelNavigation");
+			if (_navigationPanel == null)
+                return;
             var hideNavigationOnStartup = ((IModelOptionsNavigationContainer)Application.Model.Options).HideNavigationOnStartup;
             _navigationPanel.Visibility = hideNavigationOnStartup != null && hideNavigationOnStartup.Value ? DockVisibility.AutoHide : DockVisibility.Visible;
         }


### PR DESCRIPTION
It fixes the bug as described in [DockManagerOnLoad throws Sequence contains no matching element](http://www.expandframework.com/support/forum/6-bugs/5023-dockmanageronload-throws-sequence-contains-no-matching-element.html).